### PR TITLE
Update RCRelativeLayout.java

### DIFF
--- a/RCLayout/rclayout/src/main/java/com/gcssloop/widget/RCRelativeLayout.java
+++ b/RCLayout/rclayout/src/main/java/com/gcssloop/widget/RCRelativeLayout.java
@@ -137,6 +137,7 @@ public class RCRelativeLayout extends RelativeLayout {
             canvas.drawPath(mStrokePath, mPaint);
 
         }
+        mPaint.setColor(Color.WHITE);
         mPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_IN));
         mPaint.setStrokeWidth(0);
         mPaint.setStyle(Paint.Style.FILL);


### PR DESCRIPTION
fix : when the stroke_color contains a alpha,  the alpha layer covers the whole layout.