### PR TITLE
修复没有背景时,动态改变RoundAsCircle无效;调整了示例

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity android:name=".AntiAliasActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/gcssloop/roundcornerlayouttest/AntiAliasActivity.java
+++ b/app/src/main/java/com/gcssloop/roundcornerlayouttest/AntiAliasActivity.java
@@ -1,0 +1,17 @@
+package com.gcssloop.roundcornerlayouttest;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * @author dengyuhan
+ * created 2018/11/12 16:40
+ */
+public class AntiAliasActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_antialias);
+    }
+}

--- a/app/src/main/java/com/gcssloop/roundcornerlayouttest/ExampleActivity.java
+++ b/app/src/main/java/com/gcssloop/roundcornerlayouttest/ExampleActivity.java
@@ -22,6 +22,7 @@
 
 package com.gcssloop.roundcornerlayouttest;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -37,11 +38,13 @@ public class ExampleActivity extends AppCompatActivity {
     RCRelativeLayout layout;
     CheckBox cb_clip_background;
     CheckBox cb_circle;
+    CheckBox cb_background;
     SeekBar seekbar_stroke_width;
     SeekBar seekbar_radius_top_left;
     SeekBar seekbar_radius_top_right;
     SeekBar seekbar_radius_bottom_left;
     SeekBar seekbar_radius_bottom_right;
+    Toast toast;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,6 +52,7 @@ public class ExampleActivity extends AppCompatActivity {
         setContentView(R.layout.activity_example);
         layout = (RCRelativeLayout) findViewById(R.id.rc_layout);
         cb_circle = (CheckBox) findViewById(R.id.cb_circle);
+        cb_background = (CheckBox) findViewById(R.id.cb_background);
         cb_clip_background = (CheckBox) findViewById(R.id.cb_clip_background);
         seekbar_stroke_width = (SeekBar) findViewById(R.id.seekbar_stroke_width);
         seekbar_radius_top_left = (SeekBar) findViewById(R.id.seekbar_radius_top_left);
@@ -57,7 +61,8 @@ public class ExampleActivity extends AppCompatActivity {
         seekbar_radius_bottom_right = (SeekBar) findViewById(R.id.seekbar_radius_bottom_right);
 
         //checked状态
-        final Toast toast = Toast.makeText(this, "", Toast.LENGTH_SHORT);
+        toast = Toast.makeText(this, "", Toast.LENGTH_SHORT);
+
         layout.setOnCheckedChangeListener(new RCHelper.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(View v, boolean isChecked) {
@@ -69,6 +74,18 @@ public class ExampleActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 layout.toggle();
+            }
+        });
+        //背景色
+        cb_background.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (isChecked) {
+                    layout.setBackgroundResource(R.color.colorBackground);
+                } else {
+                    layout.setBackground(null);
+                }
+                cb_clip_background.setVisibility(isChecked ? View.VISIBLE : View.GONE);
             }
         });
         //剪裁背景
@@ -83,6 +100,8 @@ public class ExampleActivity extends AppCompatActivity {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 layout.setRoundAsCircle(isChecked);
+
+                findViewById(R.id.layout_radius).setVisibility(isChecked ? View.INVISIBLE : View.VISIBLE);
             }
         });
         //边框粗细
@@ -121,13 +140,17 @@ public class ExampleActivity extends AppCompatActivity {
             }
         });
         seekbar_stroke_width.setProgress(getResources().getDimensionPixelSize(R.dimen.default_stroke_width));
-        cb_clip_background.setChecked(true);
 
+        cb_circle.setChecked(true);
     }
 
     private int getProgressRadius(int progress) {
         int size = getResources().getDimensionPixelOffset(R.dimen.size_example_image);
         return (int) ((float) progress / 100 * size) / 2;
+    }
+
+    public void clickAntiAlias(View view) {
+        startActivity(new Intent(this,AntiAliasActivity.class));
     }
 
 

--- a/app/src/main/res/layout/activity_antialias.xml
+++ b/app/src/main/res/layout/activity_antialias.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorActivityBackground"
+    android:gravity="center">
+
+    <RelativeLayout
+        android:id="@+id/layout_sawtooth"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_centerHorizontal="true"
+            android:id="@+id/tv_sawtooth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="有锯齿"
+            android:textColor="@android:color/white" />
+
+        <com.gcssloop.widget.RCRelativeLayout
+            android:layout_centerHorizontal="true"
+            android:layout_below="@id/tv_sawtooth"
+            android:layout_width="@dimen/small_size_example_image"
+            android:layout_height="@dimen/small_size_example_image"
+            android:background="@color/colorBackground"
+            app:clip_background="true"
+            app:round_as_circle="true"
+            app:stroke_color="@color/colorPrimary"
+            app:stroke_width="@dimen/default_stroke_width">
+
+        </com.gcssloop.widget.RCRelativeLayout>
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:layout_marginTop="40dp"
+        android:layout_below="@id/layout_sawtooth"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <TextView
+            android:id="@+id/tv_no_sawtooth"
+            android:layout_centerHorizontal="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="无锯齿"
+            android:textColor="@android:color/white" />
+
+        <com.gcssloop.widget.RCRelativeLayout
+            android:layout_below="@id/tv_no_sawtooth"
+            android:layout_centerHorizontal="true"
+            android:layout_width="@dimen/small_size_example_image"
+            android:layout_height="@dimen/small_size_example_image"
+            app:round_as_circle="true"
+            app:stroke_color="@color/colorPrimary"
+            app:stroke_width="@dimen/default_stroke_width">
+
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/colorBackground" />
+        </com.gcssloop.widget.RCRelativeLayout>
+    </RelativeLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_example.xml
+++ b/app/src/main/res/layout/activity_example.xml
@@ -3,124 +3,154 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#5F5652"
-    android:gravity="center">
+    android:background="@color/colorActivityBackground">
 
-    <com.gcssloop.widget.RCRelativeLayout
-        android:id="@+id/rc_layout"
-        android:layout_width="@dimen/size_example_image"
-        android:layout_height="@dimen/size_example_image"
-        android:layout_centerHorizontal="true"
-        android:background="@color/colorPrimary"
-        app:stroke_color="@drawable/selector_stroke_color">
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            android:src="@drawable/test" />
-
-    </com.gcssloop.widget.RCRelativeLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
+    <TextView
+        android:layout_alignParentRight="true"
+        android:id="@+id/tv_antialias"
+        android:layout_margin="10dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/rc_layout"
-        android:layout_marginTop="30dp"
-        android:orientation="vertical"
-        android:paddingLeft="15dp">
+        android:onClick="clickAntiAlias"
+        android:text="裁剪背景后有锯齿?"
+        android:textColor="@android:color/white" />
+
+    <RelativeLayout
+        android:layout_below="@id/tv_antialias"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center">
+
+        <com.gcssloop.widget.RCRelativeLayout
+            android:id="@+id/rc_layout"
+            android:layout_width="@dimen/size_example_image"
+            android:layout_height="@dimen/size_example_image"
+            android:layout_centerHorizontal="true"
+            app:stroke_color="@drawable/selector_stroke_color">
+
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="centerCrop"
+                android:src="@drawable/test" />
+
+        </com.gcssloop.widget.RCRelativeLayout>
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
-            android:layout_marginBottom="10dp"
-            android:layout_marginRight="15dp">
+            android:layout_below="@id/rc_layout"
+            android:layout_marginTop="30dp"
+            android:orientation="vertical"
+            android:paddingLeft="15dp">
 
-            <CheckBox
-                android:id="@+id/cb_clip_background"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="剪裁背景"
-                android:textColor="@android:color/white" />
+                android:layout_gravity="right"
+                android:layout_marginRight="15dp"
+                android:layout_marginBottom="10dp">
 
-            <CheckBox
-                android:id="@+id/cb_circle"
-                android:layout_width="wrap_content"
+                <CheckBox
+                    android:id="@+id/cb_clip_background"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="剪裁背景"
+                    android:textColor="@android:color/white"
+                    android:visibility="gone" />
+
+                <CheckBox
+                    android:id="@+id/cb_background"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="背景色"
+                    android:textColor="@android:color/white" />
+
+                <CheckBox
+                    android:id="@+id/cb_circle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="15dp"
+                    android:text="圆形"
+                    android:textColor="@android:color/white" />
+            </LinearLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    style="@style/tv_label_example"
+                    android:text="StrokeWidth：" />
+
+                <SeekBar
+                    android:id="@+id/seekbar_stroke_width"
+                    style="@style/seekbar_example" />
+            </RelativeLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_radius"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:text="圆形"
-                android:textColor="@android:color/white" />
+                android:orientation="vertical">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp">
+
+                    <TextView
+                        style="@style/tv_label_example"
+                        android:text="TopLeftRadius：" />
+
+                    <SeekBar
+                        android:id="@+id/seekbar_radius_top_left"
+                        style="@style/seekbar_example" />
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp">
+
+                    <TextView
+                        style="@style/tv_label_example"
+                        android:text="TopRightRadius：" />
+
+                    <SeekBar
+                        android:id="@+id/seekbar_radius_top_right"
+                        style="@style/seekbar_example" />
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp">
+
+                    <TextView
+                        style="@style/tv_label_example"
+                        android:text="BottomLeftRadius：" />
+
+                    <SeekBar
+                        android:id="@+id/seekbar_radius_bottom_left"
+                        style="@style/seekbar_example" />
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        style="@style/tv_label_example"
+                        android:text="BottomRightRadius：" />
+
+                    <SeekBar
+                        android:id="@+id/seekbar_radius_bottom_right"
+                        style="@style/seekbar_example" />
+                </RelativeLayout>
+            </LinearLayout>
         </LinearLayout>
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <TextView
-                style="@style/tv_label_example"
-                android:text="StrokeWidth：" />
-
-            <SeekBar
-                android:id="@+id/seekbar_stroke_width"
-                style="@style/seekbar_example" />
-        </RelativeLayout>
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp">
-
-            <TextView
-                style="@style/tv_label_example"
-                android:text="TopLeftRadius：" />
-
-            <SeekBar
-                android:id="@+id/seekbar_radius_top_left"
-                style="@style/seekbar_example" />
-        </RelativeLayout>
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp">
-
-            <TextView
-                style="@style/tv_label_example"
-                android:text="TopRightRadius：" />
-
-            <SeekBar
-                android:id="@+id/seekbar_radius_top_right"
-                style="@style/seekbar_example" />
-        </RelativeLayout>
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp">
-
-            <TextView
-                style="@style/tv_label_example"
-                android:text="BottomLeftRadius：" />
-
-            <SeekBar
-                android:id="@+id/seekbar_radius_bottom_left"
-                style="@style/seekbar_example" />
-        </RelativeLayout>
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:gravity="center_vertical">
-
-            <TextView
-                style="@style/tv_label_example"
-                android:text="BottomRightRadius：" />
-
-            <SeekBar
-                android:id="@+id/seekbar_radius_bottom_right"
-                style="@style/seekbar_example" />
-        </RelativeLayout>
-    </LinearLayout>
+    </RelativeLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#5F5652"
+    android:background="@color/colorActivityBackground"
     android:onClick="bgclick"
     android:orientation="vertical"
     android:padding="20dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,6 +25,8 @@
     <color name="colorPrimary">#E39E83</color>
     <color name="colorPrimaryDark">#E39E83</color>
     <color name="colorAccent">#E39E83</color>
+    <color name="colorActivityBackground">#5F5652</color>
+    <color name="colorBackground">#FAD9DC</color>
     <color name="colorPressedColor">#A97661</color>
     <color name="colorCheckedColor">#48B7FD</color>
     <color name="colorPressedCheckedColor">#3993cc</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="small_size_example_image">250dp</dimen>
     <dimen name="size_example_image">300dp</dimen>
     <dimen name="default_stroke_width">5dp</dimen>
 </resources>

--- a/rclayout/src/main/java/com/gcssloop/widget/RCRelativeLayout.java
+++ b/rclayout/src/main/java/com/gcssloop/widget/RCRelativeLayout.java
@@ -27,14 +27,11 @@ import android.graphics.Canvas;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;
-import android.view.View;
 import android.widget.Checkable;
 import android.widget.RelativeLayout;
 
 import com.gcssloop.widget.helper.RCAttrs;
 import com.gcssloop.widget.helper.RCHelper;
-
-import java.util.ArrayList;
 
 
 /**
@@ -68,14 +65,15 @@ public class RCRelativeLayout extends RelativeLayout implements Checkable, RCAtt
     protected void dispatchDraw(Canvas canvas) {
         canvas.saveLayer(mRCHelper.mLayer, null, Canvas.ALL_SAVE_FLAG);
         super.dispatchDraw(canvas);
+        mRCHelper.refreshRegion(this);
         mRCHelper.onClipDraw(canvas);
         canvas.restore();
     }
 
     @Override
     public void draw(Canvas canvas) {
-        mRCHelper.refreshRegion(this);
         if (mRCHelper.mClipBackground) {
+            mRCHelper.refreshRegion(this);
             canvas.save();
             canvas.clipPath(mRCHelper.mClipPath);
             super.draw(canvas);


### PR DESCRIPTION
#### 1. 修复没有背景时,动态改变RoundAsCircle无效;
没有设置背景时，通过代码动态设置RoundAsCircle，没有效果，只回调了`dispatchDraw`，没有回调`draw`，所以将`mRCHelper.refreshRegion(this);`移到了`dispatchDraw`，可以解决

![1](https://user-images.githubusercontent.com/17588779/48338417-909a7e80-e6a0-11e8-928c-696ff238abec.gif)

之后出现新问题，有背景时，并且ClipBackground是true，代码首次设置RoundAsCircle为true不会剪裁背景，再设置回false，边框没有变圆形
![2](https://user-images.githubusercontent.com/17588779/48339348-f982f600-e6a2-11e8-98be-e0f8cab7ae19.gif)


所以`dispatchDraw`，`draw`都需要刷新一下

#### 2.调整了示例的交互
![调整了示例的交互](https://user-images.githubusercontent.com/17588779/48339071-313d6e00-e6a2-11e8-832b-09e585154452.gif)

#### 3.增加了一个裁剪背景锯齿的替代方案示例

